### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/DevOpsProject29012/0fc183fd-b65e-45bb-83aa-49eb9081558d/aa312f87-a22b-44ec-a789-809222cc3173/_apis/work/boardbadge/7359b014-8689-49b5-a318-529760776680)](https://dev.azure.com/DevOpsProject29012/0fc183fd-b65e-45bb-83aa-49eb9081558d/_boards/board/t/aa312f87-a22b-44ec-a789-809222cc3173/Microsoft.EpicCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/DevOpsProject29012/0fc183fd-b65e-45bb-83aa-49eb9081558d/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.